### PR TITLE
Update and delete profile picture

### DIFF
--- a/src/api/users/user.ts
+++ b/src/api/users/user.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getDoctorNameAPI, userAPI } from "../apiConfig";
+import { adminAPI, getDoctorNameAPI, userAPI } from "../apiConfig";
 import { retrieveAccessTokenFromCookie } from "./auth";
 
 export interface RequestResetPasswordForm {
@@ -316,6 +316,26 @@ export const fetchUserProfilePhoto = async () => {
     return response?.data?.image_url;
   } catch (error) {
     console.error("GET fetch user profile photo", error);
+    throw error;
+  }
+};
+
+export const updateUserProfilePhotoByAdmin = async (userId: String, formData: FormData) => {
+  try {
+    const token = retrieveAccessTokenFromCookie();
+    if (!token) throw new Error("No token found.");
+
+    const response = await adminAPI.post(`/user/${userId}/upload_profile_pic/`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    console.log("POST update user profile photo by admin", response.data);
+    return response.data;
+  } catch (error) {
+    console.error("POST update user profile photo by admin", error);
     throw error;
   }
 };

--- a/src/api/users/user.ts
+++ b/src/api/users/user.ts
@@ -360,6 +360,24 @@ export const updateUserProfilePhoto = async (formData: FormData) => {
   }
 };
 
+export const deleteUserProfilePhotoByAdmin = async (userId: String) => {
+  try {
+    const token = retrieveAccessTokenFromCookie();
+    if (!token) throw new Error("No token found.");
+
+    const response = await adminAPI.delete(`/user/${userId}/delete_profile_pic/`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error("DELETE delete user profile photo by admin", error);
+    throw error;
+  }
+};
+
 export const deleteUserProfilePhoto = async () => {
   try {
     const token = retrieveAccessTokenFromCookie();

--- a/src/components/Modal/ConfirmProfilePhotoModalAdmin.tsx
+++ b/src/components/Modal/ConfirmProfilePhotoModalAdmin.tsx
@@ -13,10 +13,11 @@ import {
 
 const ConfirmProfilePhotoModalAdmin: React.FC = () => {
   const { modalRef, activeModal, closeModal } = useModal();
-  const { tempPhoto, refreshProfile, userId } = activeModal.props as {
+  const { tempPhoto, refreshProfile, userId, accountName } = activeModal.props as {
     tempPhoto?: string;
     refreshProfile: () => void;
     userId: string;
+    accountName: string;
   };
   const [isLoading, setIsLoading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -81,7 +82,7 @@ const ConfirmProfilePhotoModalAdmin: React.FC = () => {
       clearInterval(uploadSimulation);
       setUploadProgress(100);
       closeModal();
-      toast.success(`Update ${userId} profile photo successfully`);
+      toast.success(`Updated profile photo for ${accountName} successfully`);
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
@@ -90,15 +91,15 @@ const ConfirmProfilePhotoModalAdmin: React.FC = () => {
       if (error instanceof AxiosError) {
         if (error.response?.status && error.response?.data?.detail) {
           toast.error(
-            `Failed to update ${userId} profile photo. Error ${error.response?.status}: ${error.response?.data?.detail}`
+            `Failed to update profile photo for ${accountName}. Error ${error.response?.status}: ${error.response?.data?.detail}`
           );
         } else {
           toast.error(
-            `Error ${error.response?.status}: Failed to update ${userId} profile photo.`
+            `Error ${error.response?.status}: Failed to update profile photo for ${accountName}.`
           );
         }
       } else {
-        toast.error(`Failed to update ${userId} profile photo.`);
+        toast.error(`Failed to update profile photo for ${accountName}.`);
       }
     } finally {
       setIsLoading(false);

--- a/src/components/Modal/ConfirmProfilePhotoModalAdmin.tsx
+++ b/src/components/Modal/ConfirmProfilePhotoModalAdmin.tsx
@@ -1,0 +1,157 @@
+import { AxiosError } from "axios";
+import { useModal } from "@/hooks/useModal";
+import { Button } from "../ui/button";
+import { Avatar, AvatarFallback } from "../ui/avatar";
+import { AvatarImage } from "@radix-ui/react-avatar";
+import { Loader2, UserRound } from "lucide-react";
+import { toast } from "sonner";
+import { useState } from "react";
+import { Progress } from "../ui/progress";
+import {
+  updateUserProfilePhoto,
+  updateUserProfilePhotoByAdmin,
+} from "@/api/users/user";
+import { updatePatientProfilePhoto } from "@/api/patients/patients";
+
+const ConfirmProfilePhotoModalAdmin: React.FC = () => {
+  const { modalRef, activeModal, closeModal } = useModal();
+  const { tempPhoto, refreshProfile, userId } = activeModal.props as {
+    tempPhoto?: string;
+    refreshProfile: () => void;
+    userId: string;
+  };
+  const [isLoading, setIsLoading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+
+  const base64ToFile = (base64: string, baseFilename: string): File => {
+    const [metadata, data] = base64.split(",");
+
+    const mimeMatch = metadata.match(/:(.*?);/);
+    if (!mimeMatch) {
+      throw new Error(
+        "Invalid base64 string, MIME type could not be determined."
+      );
+    }
+
+    const mime = mimeMatch[1];
+    if (!["image/jpeg", "image/png"].includes(mime)) {
+      throw new Error(
+        "Unsupported image format. Please upload a JPG, JPEG, or PNG image."
+      );
+    }
+
+    const extension = mime === "image/png" ? "png" : "jpg"; // Determine correct extension
+    const filename = `${baseFilename}.${extension}`; // Append extension
+
+    const binary = atob(data);
+    const array = new Uint8Array(binary.length);
+
+    for (let i = 0; i < binary.length; i++) {
+      array[i] = binary.charCodeAt(i);
+    }
+
+    return new File([array], filename, { type: mime });
+  };
+
+  const handleConfirmProfilePhoto = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!tempPhoto) {
+      console.log("No photo selected!");
+      return;
+    }
+
+    setIsLoading(true);
+    setUploadProgress(0);
+
+    const formData = new FormData();
+    const file = base64ToFile(tempPhoto, "profile_picture");
+    formData.append("file", file);
+
+    try {
+      // Simulate upload progress
+      const uploadSimulation = setInterval(() => {
+        setUploadProgress((prevProgress: number) => {
+          const newProgress = prevProgress + 10;
+          return newProgress > 90 ? 90 : newProgress;
+        });
+      }, 200);
+
+      await updateUserProfilePhotoByAdmin(userId, formData);
+
+      refreshProfile();
+      clearInterval(uploadSimulation);
+      setUploadProgress(100);
+      closeModal();
+      toast.success(`Update ${userId} profile photo successfully`);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      closeModal();
+      
+      if (error instanceof AxiosError) {
+        if (error.response?.status && error.response?.data?.detail) {
+          toast.error(
+            `Failed to update ${userId} profile photo. Error ${error.response?.status}: ${error.response?.data?.detail}`
+          );
+        } else {
+          toast.error(
+            `Error ${error.response?.status}: Failed to update ${userId} profile photo.`
+          );
+        }
+      } else {
+        toast.error(`Failed to update ${userId} profile photo.`);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div ref={modalRef} className="bg-background p-8 rounded-md w-[500px]">
+        <h3 className="text-lg font-medium mb-1">Confirm Profile Photo </h3>
+        <p className="mb-6 text-gray-600 dark:text-gray-200 mb-5">
+          Is this the photo you want to use for your profile photo?
+        </p>
+        <form
+          className="grid grid-cols-1 gap-4"
+          onSubmit={handleConfirmProfilePhoto}
+        >
+          <div className="flex justify-center col-span-1">
+            <Avatar className="h-52 w-52">
+              <AvatarImage src={tempPhoto || ""} alt="Profile" />
+              <AvatarFallback>
+                <UserRound className="w-48 h-48 text-gray-500" />
+              </AvatarFallback>
+            </Avatar>
+          </div>
+
+          {isLoading && (
+            <div className="col-span-1 mt-6">
+              <Progress value={uploadProgress} className="w-full" />
+              <p className="text-sm text-gray-500 mt-2 text-center">
+                Uploading... {uploadProgress}%
+              </p>
+              <div className="flex items-center justify-center mt-4">
+                <Loader2 className="h-6 w-6 animate-spin mr-2" />
+                <span>Processing your photo...</span>
+              </div>
+            </div>
+          )}
+
+          {!isLoading && (
+            <div className="col-span-1 mt-6 flex justify-end space-x-2">
+              <Button variant="outline" onClick={closeModal}>
+                Cancel
+              </Button>
+              <Button type="submit">Confirm</Button>
+            </div>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmProfilePhotoModalAdmin;

--- a/src/components/Modal/ConfirmProfilePhotoModalAdmin.tsx
+++ b/src/components/Modal/ConfirmProfilePhotoModalAdmin.tsx
@@ -8,10 +8,8 @@ import { toast } from "sonner";
 import { useState } from "react";
 import { Progress } from "../ui/progress";
 import {
-  updateUserProfilePhoto,
   updateUserProfilePhotoByAdmin,
 } from "@/api/users/user";
-import { updatePatientProfilePhoto } from "@/api/patients/patients";
 
 const ConfirmProfilePhotoModalAdmin: React.FC = () => {
   const { modalRef, activeModal, closeModal } = useModal();

--- a/src/components/Modal/Delete/DeleteProfilePhotoModalAdmin.tsx
+++ b/src/components/Modal/Delete/DeleteProfilePhotoModalAdmin.tsx
@@ -6,9 +6,10 @@ import { AxiosError } from "axios";
 
 const DeleteProfilePhotoModalAdmin: React.FC = () => {
   const { modalRef, activeModal, closeModal } = useModal();
-  const { refreshProfile, userId } = activeModal.props as {
+  const { refreshProfile, userId, accountName } = activeModal.props as {
     refreshProfile: () => void;
     userId: string;
+    accountName: string;
   };
 
   const handleDeletePhoto = async (event: React.FormEvent) => {
@@ -18,22 +19,22 @@ const DeleteProfilePhotoModalAdmin: React.FC = () => {
       await deleteUserProfilePhotoByAdmin(userId);
       refreshProfile();
       closeModal();
-      toast.success("User profile photo deleted successfully.");
+      toast.success(`Deleted profile photo for ${accountName} successfully.`);
     } catch (error) {
       closeModal();
 
       if (error instanceof AxiosError) {
         if (error.response?.status && error.response?.data?.detail) {
           toast.error(
-            `Failed to update ${userId} profile photo. Error ${error.response?.status}: ${error.response?.data?.detail}`
+            `Failed to delete profile photo for ${accountName}. Error ${error.response?.status}: ${error.response?.data?.detail}`
           );
         } else {
           toast.error(
-            `Error ${error.response?.status}: Failed to update ${userId} profile photo.`
+            `Error ${error.response?.status}: Failed to delete profile photo for ${accountName}.`
           );
         }
       } else {
-        toast.error(`Failed to update ${userId} profile photo.`);
+        toast.error(`Failed to delete profile photo for ${accountName}.`);
       }
     }
   };

--- a/src/components/Modal/Delete/DeleteProfilePhotoModalAdmin.tsx
+++ b/src/components/Modal/Delete/DeleteProfilePhotoModalAdmin.tsx
@@ -1,0 +1,52 @@
+import { toast } from "sonner";
+import { useModal } from "@/hooks/useModal";
+import { deleteUserProfilePhotoByAdmin } from "@/api/users/user";
+import BaseDeleteModal from "./BaseDeleteModal";
+import { AxiosError } from "axios";
+
+const DeleteProfilePhotoModalAdmin: React.FC = () => {
+  const { modalRef, activeModal, closeModal } = useModal();
+  const { refreshProfile, userId } = activeModal.props as {
+    refreshProfile: () => void;
+    userId: string;
+  };
+
+  const handleDeletePhoto = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    try {
+      await deleteUserProfilePhotoByAdmin(userId);
+      refreshProfile();
+      closeModal();
+      toast.success("User profile photo deleted successfully.");
+    } catch (error) {
+      closeModal();
+
+      if (error instanceof AxiosError) {
+        if (error.response?.status && error.response?.data?.detail) {
+          toast.error(
+            `Failed to update ${userId} profile photo. Error ${error.response?.status}: ${error.response?.data?.detail}`
+          );
+        } else {
+          toast.error(
+            `Error ${error.response?.status}: Failed to update ${userId} profile photo.`
+          );
+        }
+      } else {
+        toast.error(`Failed to update ${userId} profile photo.`);
+      }
+    }
+  };
+
+  return (
+    <>
+      <BaseDeleteModal
+        modalRef={modalRef}
+        onSubmit={handleDeletePhoto}
+        closeModal={closeModal}
+      />
+    </>
+  );
+};
+
+export default DeleteProfilePhotoModalAdmin;

--- a/src/components/Modal/UploadProfilePhotoModalAdmin.tsx
+++ b/src/components/Modal/UploadProfilePhotoModalAdmin.tsx
@@ -5,9 +5,10 @@ import { useState } from "react";
 
 const ProfilePhotoInputModalAdmin: React.FC = () => {
   const { modalRef, activeModal, openModal, closeModal } = useModal();
-  const { refreshProfile, userId } = activeModal.props as {
+  const { refreshProfile, userId, accountName } = activeModal.props as {
     refreshProfile: () => void;
     userId: string;
+    accountName: string;
   };
 
   const [error, setError] = useState("");
@@ -38,6 +39,7 @@ const ProfilePhotoInputModalAdmin: React.FC = () => {
           tempPhoto: reader.result as string,
           refreshProfile,
           userId,
+          accountName,
         });
       };
       reader.readAsDataURL(file);

--- a/src/components/Modal/UploadProfilePhotoModalAdmin.tsx
+++ b/src/components/Modal/UploadProfilePhotoModalAdmin.tsx
@@ -1,0 +1,74 @@
+import { useModal } from "@/hooks/useModal";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { useState } from "react";
+
+const ProfilePhotoInputModalAdmin: React.FC = () => {
+  const { modalRef, activeModal, openModal, closeModal } = useModal();
+  const { refreshProfile, userId } = activeModal.props as {
+    refreshProfile: () => void;
+    userId: string;
+  };
+
+  const [error, setError] = useState("");
+
+  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      // Check if the file is an image type (jpg, jpeg, png)
+      const validTypes = ["image/jpeg", "image/png"];
+      if (!validTypes.includes(file.type)) {
+        setError("Please upload a JPG, JPEG, or PNG file.");
+        return;
+      }
+
+      // Check if the file size is under 2MB (2MB = 2,000,000 bytes)
+      if (file.size >= 2_000_000) {
+        setError(
+          "The file is too large. Please upload a file no more than 2MB."
+        );
+        return;
+      }
+      setError("");
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        closeModal();
+        openModal("confirmProfilePhoto", {
+          tempPhoto: reader.result as string,
+          refreshProfile,
+          userId,
+        });
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div ref={modalRef} className="bg-background p-8 rounded-md w-[400px]">
+        <h3 className="text-lg font-medium mb-1">Upload Profile Photo </h3>
+        <p className="mb-6 text-gray-600 dark:text-gray-200 mb-5">
+          Select a profile photo to upload.
+        </p>
+        <form className="grid grid-cols-2 gap-4">
+          <div className="col-span-2">
+            <Input
+              type="file"
+              accept="image/*"
+              onChange={handleFileUpload}
+            ></Input>
+          </div>
+          {error && <div className="col-span-2 text-red-600 mb-2">{error}</div>}
+          <div className="col-span-2 mt-6 flex justify-end space-x-2">
+            <Button variant="outline" onClick={closeModal}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePhotoInputModalAdmin;

--- a/src/pages/Admin/ViewAccount.tsx
+++ b/src/pages/Admin/ViewAccount.tsx
@@ -51,44 +51,42 @@ const ViewAccount: React.FC = () => {
                   </p>
                 </AvatarFallback>
               </Avatar>
-              {currentUser?.roleName === "ADMIN" && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button size="sm" className="absolute bottom-2 left-2">
-                      Edit
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="w-48">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button size="sm" className="absolute bottom-2 left-2">
+                    Edit
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-48">
+                  <DropdownMenuItem
+                    onClick={() =>
+                      openModal("uploadProfilePhoto", {
+                        refreshProfile: refreshAccountData,
+                        userId: id,
+                      })
+                    }
+                  >
+                    <Upload className="mr-2 h-4 w-4" />
+                    Upload Photo
+                  </DropdownMenuItem>
+                  {accountInfo?.profilePicture?.includes(
+                    "https://res.cloudinary.com"
+                  ) && (
                     <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
                       onClick={() =>
-                        openModal("uploadProfilePhoto", {
+                        openModal("deleteProfilePhoto", {
                           refreshProfile: refreshAccountData,
                           userId: id,
                         })
                       }
                     >
-                      <Upload className="mr-2 h-4 w-4" />
-                      Upload Photo
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Remove Photo
                     </DropdownMenuItem>
-                    {accountInfo?.profilePicture?.includes(
-                      "https://res.cloudinary.com"
-                    ) && (
-                      <DropdownMenuItem
-                        className="text-destructive focus:text-destructive"
-                        onClick={() =>
-                          openModal("deleteProfilePhoto", {
-                            refreshProfile: refreshAccountData,
-                            userId: id,
-                          })
-                        }
-                      >
-                        <Trash2 className="mr-2 h-4 w-4" />
-                        Remove Photo
-                      </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
             <div>
               <h1 className="text-2xl font-bold">
@@ -96,6 +94,7 @@ const ViewAccount: React.FC = () => {
               </h1>
               <p className="text-gray-600">{accountInfo?.roleName}</p>
               <p className="text-gray-600">{accountInfo?.email}</p>
+              <p className="text-gray-600">{accountInfo?.id}</p>
             </div>
             <div className="!ml-auto space-x-2">
               <Button

--- a/src/pages/Admin/ViewAccount.tsx
+++ b/src/pages/Admin/ViewAccount.tsx
@@ -60,6 +60,7 @@ const ViewAccount: React.FC = () => {
                       openModal("uploadProfilePhoto", {
                         refreshProfile: refreshAccountData,
                         userId: id,
+                        accountName: accountInfo?.nric_FullName,
                       })
                     }
                   >
@@ -75,6 +76,7 @@ const ViewAccount: React.FC = () => {
                         openModal("deleteProfilePhoto", {
                           refreshProfile: refreshAccountData,
                           userId: id,
+                          accountName: accountInfo?.nric_FullName,
                         })
                       }
                     >

--- a/src/pages/Admin/ViewAccount.tsx
+++ b/src/pages/Admin/ViewAccount.tsx
@@ -15,10 +15,19 @@ import EditAccountInfoModal from "@/components/Modal/Edit/EditAccountInfoModal";
 import DeleteAccountModal from "@/components/Modal/Delete/DeleteAccountModal";
 import { useViewAccount } from "@/hooks/admin/useViewAccount";
 import AccountInfoTab from "@/components/Tab/AccountInfoTab";
+import ConfirmProfilePhotoModal from "@/components/Modal/ConfirmProfilePhotoModal";
+import DeleteProfilePhotoModal from "@/components/Modal/Delete/DeleteProfilePhotoModal";
 
 const ViewAccount: React.FC = () => {
   const { currentUser } = useAuth();
-  const { id, accountInfo, nricData, getNRIC, setAccountInfo, refreshAccountData } = useViewAccount();
+  const {
+    id,
+    accountInfo,
+    nricData,
+    getNRIC,
+    setAccountInfo,
+    refreshAccountData,
+  } = useViewAccount();
   const { activeModal, openModal } = useModal();
 
   return (
@@ -94,7 +103,7 @@ const ViewAccount: React.FC = () => {
                 variant="default"
                 onClick={() =>
                   openModal("editAccountInfo", {
-                    accountInfo:{
+                    accountInfo: {
                       ...accountInfo,
                       nric: getNRIC(),
                       unmaskedNRIC: nricData.nric,
@@ -125,9 +134,13 @@ const ViewAccount: React.FC = () => {
         {activeModal.name === "uploadProfilePhoto" && (
           <UploadProfilePhotoModal />
         )}
-        {activeModal.name === "editAccountInfo" && (
-          <EditAccountInfoModal />
+        {activeModal.name === "confirmProfilePhoto" && (
+          <ConfirmProfilePhotoModal />
         )}
+        {activeModal.name === "deleteProfilePhoto" && (
+          <DeleteProfilePhotoModal />
+        )}
+        {activeModal.name === "editAccountInfo" && <EditAccountInfoModal />}
         {activeModal.name === "deleteAccount" && <DeleteAccountModal />}
       </div>
     </>

--- a/src/pages/Admin/ViewAccount.tsx
+++ b/src/pages/Admin/ViewAccount.tsx
@@ -17,6 +17,7 @@ import { useViewAccount } from "@/hooks/admin/useViewAccount";
 import AccountInfoTab from "@/components/Tab/AccountInfoTab";
 import ConfirmProfilePhotoModalAdmin from "@/components/Modal/ConfirmProfilePhotoModalAdmin";
 import DeleteProfilePhotoModal from "@/components/Modal/Delete/DeleteProfilePhotoModal";
+import DeleteProfilePhotoModalAdmin from "@/components/Modal/Delete/DeleteProfilePhotoModalAdmin";
 
 const ViewAccount: React.FC = () => {
   const { currentUser } = useAuth();
@@ -77,8 +78,7 @@ const ViewAccount: React.FC = () => {
                         onClick={() =>
                           openModal("deleteProfilePhoto", {
                             refreshProfile: refreshAccountData,
-                            isUser: false,
-                            patientId: id,
+                            userId: id,
                           })
                         }
                       >
@@ -137,7 +137,7 @@ const ViewAccount: React.FC = () => {
           <ConfirmProfilePhotoModalAdmin />
         )}
         {activeModal.name === "deleteProfilePhoto" && (
-          <DeleteProfilePhotoModal />
+          <DeleteProfilePhotoModalAdmin />
         )}
         {activeModal.name === "editAccountInfo" && <EditAccountInfoModal />}
         {activeModal.name === "deleteAccount" && <DeleteAccountModal />}

--- a/src/pages/Admin/ViewAccount.tsx
+++ b/src/pages/Admin/ViewAccount.tsx
@@ -10,12 +10,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Trash2, Upload } from "lucide-react";
-import UploadProfilePhotoModal from "@/components/Modal/UploadProfilePhotoModal";
+import UploadProfilePhotoModalAdmin from "@/components/Modal/UploadProfilePhotoModalAdmin";
 import EditAccountInfoModal from "@/components/Modal/Edit/EditAccountInfoModal";
 import DeleteAccountModal from "@/components/Modal/Delete/DeleteAccountModal";
 import { useViewAccount } from "@/hooks/admin/useViewAccount";
 import AccountInfoTab from "@/components/Tab/AccountInfoTab";
-import ConfirmProfilePhotoModal from "@/components/Modal/ConfirmProfilePhotoModal";
+import ConfirmProfilePhotoModalAdmin from "@/components/Modal/ConfirmProfilePhotoModalAdmin";
 import DeleteProfilePhotoModal from "@/components/Modal/Delete/DeleteProfilePhotoModal";
 
 const ViewAccount: React.FC = () => {
@@ -62,8 +62,7 @@ const ViewAccount: React.FC = () => {
                       onClick={() =>
                         openModal("uploadProfilePhoto", {
                           refreshProfile: refreshAccountData,
-                          isUser: false,
-                          patientId: id,
+                          userId: id,
                         })
                       }
                     >
@@ -132,10 +131,10 @@ const ViewAccount: React.FC = () => {
         </div>
 
         {activeModal.name === "uploadProfilePhoto" && (
-          <UploadProfilePhotoModal />
+          <UploadProfilePhotoModalAdmin />
         )}
         {activeModal.name === "confirmProfilePhoto" && (
-          <ConfirmProfilePhotoModal />
+          <ConfirmProfilePhotoModalAdmin />
         )}
         {activeModal.name === "deleteProfilePhoto" && (
           <DeleteProfilePhotoModal />

--- a/src/pages/Admin/ViewAccount.tsx
+++ b/src/pages/Admin/ViewAccount.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { useAuth } from "@/hooks/useAuth";
 import { useModal } from "@/hooks/useModal";
 import {
   DropdownMenu,
@@ -16,11 +15,9 @@ import DeleteAccountModal from "@/components/Modal/Delete/DeleteAccountModal";
 import { useViewAccount } from "@/hooks/admin/useViewAccount";
 import AccountInfoTab from "@/components/Tab/AccountInfoTab";
 import ConfirmProfilePhotoModalAdmin from "@/components/Modal/ConfirmProfilePhotoModalAdmin";
-import DeleteProfilePhotoModal from "@/components/Modal/Delete/DeleteProfilePhotoModal";
 import DeleteProfilePhotoModalAdmin from "@/components/Modal/Delete/DeleteProfilePhotoModalAdmin";
 
 const ViewAccount: React.FC = () => {
-  const { currentUser } = useAuth();
   const {
     id,
     accountInfo,

--- a/tests/e2e/test-edit-account.spec.ts
+++ b/tests/e2e/test-edit-account.spec.ts
@@ -13,6 +13,7 @@ dotenv.config({ path: path.resolve(__dirname, 'test.env') });
 const baseUrl = process.env.BASE_URL as string;
 const adminAccountEmail = process.env.ADMIN_ACCOUNT_EMAIL as string;
 const adminAccountPassword = process.env.ADMIN_ACCOUNT_PASSWORD as string;
+const editTestAccountID = process.env.EDIT_TEST_ACCOUNT_ID as string;
 
 /*
 Test Case: Edit Account Modal Functionality
@@ -24,7 +25,6 @@ The NRIC can be unmasked. The "Edit Account" modal shows the unmasked value.
   */
 test('Edit account modal updates preferred name and unmasks NRIC', async ({ page }) => {
   // test account id to be used in the test
-  const editTestAccountID = 'Ud3a7b1b8cc';
   // timeout used during search for the test account row
   const searchTimeout = 30000;
 
@@ -33,6 +33,7 @@ test('Edit account modal updates preferred name and unmasks NRIC', async ({ page
     await page.getByRole('textbox', { name: 'Enter a valid email address.' }).fill(adminAccountEmail);
     await page.getByRole('textbox', { name: 'Password' }).fill(adminAccountPassword);
     await page.getByRole('button', { name: 'LOGIN' }).click();
+    await page.waitForResponse(resp => resp.url().includes('/login')); // wait for login api to return
     // check that login was successful and the admin page is loaded
     await expect(page.getByText('Login successful.')).toBeVisible();
     await expect(page.locator('[id="radix-\\:rf\\:-content-all"] div').filter({ hasText: 'IDNameStatusEmailLast' }).nth(1)).toBeVisible();


### PR DESCRIPTION
This PR adds UI and functionality for admin users to upload and delete user profile photos.

Upload Profile Photo Modal (Admin):
- Allows admins to select and upload a JPG, JPEG, or PNG image (max 2MB).
- Opens a confirmation modal after successful file selection.
- Displays success/error toasts based on the API response.

Delete Profile Photo Modal (Admin):
- Allows admins to delete a user's profile photo.
- Displays success/error toasts based on the API response.